### PR TITLE
feat(backend): implemented rate limiting for APIs w/ redis

### DIFF
--- a/backend/app/routes/user.ts
+++ b/backend/app/routes/user.ts
@@ -18,16 +18,41 @@ import {
 } from '../schema/user'
 import { register, login, verifyOTP, lookup, me } from '../utils/user'
 import { authMiddleware } from '../utils/middleware/auth'
+import { rateLimiterMiddleware } from '../utils/middleware/limiter'
 
 const router = express.Router()
 
-router.post('/register', validate(registerSchema), register)
+router.post(
+    '/register',
+    rateLimiterMiddleware(),
+    validate(registerSchema),
+    register,
+)
 
-router.post('/login', validate(loginSchema), login)
+router.post(
+    '/login',
+    rateLimiterMiddleware({
+        max: 3,
+    }),
+    validate(loginSchema),
+    login,
+)
 
-router.post('/verify-otp', validate(verifyOTPSchema), verifyOTP)
+router.post(
+    '/verify-otp',
+    rateLimiterMiddleware(),
+    validate(verifyOTPSchema),
+    verifyOTP,
+)
 
-router.get('/lookup', validate(lookupSchema), lookup)
+router.get(
+    '/lookup',
+    rateLimiterMiddleware({
+        max: 20,
+    }),
+    validate(lookupSchema),
+    lookup,
+)
 
 router.get('/me', authMiddleware, validate(meSchema), me)
 

--- a/backend/app/utils/middleware/limiter.ts
+++ b/backend/app/utils/middleware/limiter.ts
@@ -1,0 +1,67 @@
+/*************************
+ *
+ * Copyright 2025 @Qreater
+ * Licensed under the Apache License, Version 2.0.
+ * See: http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *************************/
+
+import { NextFunction, Response } from 'express'
+
+import { redis } from '../database/redis'
+
+import { AuthRequest } from '../interfaces/common'
+import { APIError } from '../responses/error'
+import { logger } from '../tools/logger'
+import { config, Environment } from '../settings/config'
+
+export interface RateLimiterRule {
+    windowMs: number
+    max: number
+}
+
+const DEFAULT_RULE: RateLimiterRule = {
+    windowMs: 60_000,
+    max: 10,
+}
+
+const isLocalhost = (req: AuthRequest) =>
+    req.ip === '::1' || req.ip === '::ffff:127.0.0.1' || req.ip === '127.0.0.1'
+
+const getRateLimitKey = (req: AuthRequest) =>
+    `rate-limiter:${req.ip}:${req.path}:${req.method}`
+
+const setExpirationIfFirstRequest = async (key: string, windowMs: number) => {
+    const count = await redis.incr(key)
+    if (count === 1) {
+        await redis.expire(key, windowMs / 1000)
+    }
+    return count
+}
+
+const checkRateLimitExceeded = (key: string, count: number, max: number) => {
+    if (count > max) {
+        logger.warn(`Rate limit exceeded: ${key}`)
+        throw APIError.tooManyRequests()
+    }
+}
+
+export const rateLimiterMiddleware = (rule: Partial<RateLimiterRule> = {}) => {
+    const finalRule = { ...DEFAULT_RULE, ...rule }
+
+    return async (req: AuthRequest, _res: Response, next: NextFunction) => {
+        if (
+            isLocalhost(req) &&
+            config.environment === Environment.Development
+        ) {
+            next()
+            return
+        }
+
+        const key = getRateLimitKey(req)
+        const count = await setExpirationIfFirstRequest(key, finalRule.windowMs)
+        checkRateLimitExceeded(key, count, finalRule.max)
+
+        next()
+    }
+}

--- a/backend/app/utils/responses/error.ts
+++ b/backend/app/utils/responses/error.ts
@@ -13,6 +13,7 @@ export enum ErrorType {
     NOT_FOUND = 'not_found_error',
     VALIDATION = 'validation_error',
     UNAUTHORIZED = 'unauthorized_error',
+    TOO_MANY_REQUESTS = 'too_many_requests_error',
     SERVER_ERROR = 'server_error',
 }
 
@@ -85,6 +86,18 @@ export class APIError extends Error {
             response.errors.message,
             422,
             response.errors.additionalInfo,
+        )
+    }
+
+    static tooManyRequests(): APIError {
+        const response = createErrorResponse(
+            ErrorType.TOO_MANY_REQUESTS,
+            'Too many requests!',
+        )
+        return new APIError(
+            ErrorType.TOO_MANY_REQUESTS,
+            response.errors.message,
+            429,
         )
     }
 


### PR DESCRIPTION
# Description

- Added and configured `ErrorType.TOO_MANY_REQUESTS` for rate-limiting on APIs.
- Storing keys with IP information in Redis over a window (Expiration Time)
- Default rule for rate limits on APIs is to have `10` requests per `60` seconds, which can be overriden.

New APIs can use the rate-limiting functionality by adding
```
rateLimiterMiddleware({
    windowMs: <time_window_in_ms | default: 60_000>
    max: <max_number_of_requests_per_window | default: 10>
}),
```
To the top of their middleware chain.


## Future Plans
- A Way to implement rate-limiting based on a token/user. (**Discussion Point:** Should this be a separate middleware method, or should it be generalised along with the original rate limiting middleware?)