### PR TITLE
feat: frontend initialization

### DIFF
--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -1,0 +1,24 @@
+# Logs
+logs
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*
+lerna-debug.log*
+
+node_modules
+dist
+dist-ssr
+*.local
+
+# Editor directories and files
+.vscode/*
+!.vscode/extensions.json
+.idea
+.DS_Store
+*.suo
+*.ntvs*
+*.njsproj
+*.sln
+*.sw?

--- a/frontend/.vscode/extensions.json
+++ b/frontend/.vscode/extensions.json
@@ -1,0 +1,3 @@
+{
+  "recommendations": ["svelte.svelte-vscode"]
+}

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,0 +1,43 @@
+# Svelte + Vite
+
+This template should help get you started developing with Svelte in Vite.
+
+## Recommended IDE Setup
+
+[VS Code](https://code.visualstudio.com/) + [Svelte](https://marketplace.visualstudio.com/items?itemName=svelte.svelte-vscode).
+
+## Need an official Svelte framework?
+
+Check out [SvelteKit](https://github.com/sveltejs/kit#readme), which is also powered by Vite. Deploy anywhere with its serverless-first approach and adapt to various platforms, with out of the box support for TypeScript, SCSS, and Less, and easily-added support for mdsvex, GraphQL, PostCSS, Tailwind CSS, and more.
+
+## Technical considerations
+
+**Why use this over SvelteKit?**
+
+- It brings its own routing solution which might not be preferable for some users.
+- It is first and foremost a framework that just happens to use Vite under the hood, not a Vite app.
+
+This template contains as little as possible to get started with Vite + Svelte, while taking into account the developer experience with regards to HMR and intellisense. It demonstrates capabilities on par with the other `create-vite` templates and is a good starting point for beginners dipping their toes into a Vite + Svelte project.
+
+Should you later need the extended capabilities and extensibility provided by SvelteKit, the template has been structured similarly to SvelteKit so that it is easy to migrate.
+
+**Why include `.vscode/extensions.json`?**
+
+Other templates indirectly recommend extensions via the README, but this file allows VS Code to prompt the user to install the recommended extension upon opening the project.
+
+**Why enable `checkJs` in the JS template?**
+
+It is likely that most cases of changing variable types in runtime are likely to be accidental, rather than deliberate. This provides advanced typechecking out of the box. Should you like to take advantage of the dynamically-typed nature of JavaScript, it is trivial to change the configuration.
+
+**Why is HMR not preserving my local component state?**
+
+HMR state preservation comes with a number of gotchas! It has been disabled by default in both `svelte-hmr` and `@sveltejs/vite-plugin-svelte` due to its often surprising behavior. You can read the details [here](https://github.com/sveltejs/svelte-hmr/tree/master/packages/svelte-hmr#preservation-of-local-state).
+
+If you have state that's important to retain within a component, consider creating an external store which would not be replaced by HMR.
+
+```js
+// store.js
+// An extremely simple external store
+import { writable } from 'svelte/store'
+export default writable(0)
+```

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Bingoals</title>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="/src/main.js"></script>
+  </body>
+</html>

--- a/frontend/jsconfig.json
+++ b/frontend/jsconfig.json
@@ -1,0 +1,33 @@
+{
+  "compilerOptions": {
+    "moduleResolution": "bundler",
+    "target": "ESNext",
+    "module": "ESNext",
+    /**
+     * svelte-preprocess cannot figure out whether you have
+     * a value or a type, so tell TypeScript to enforce using
+     * `import type` instead of `import` for Types.
+     */
+    "verbatimModuleSyntax": true,
+    "isolatedModules": true,
+    "resolveJsonModule": true,
+    /**
+     * To have warnings / errors of the Svelte compiler at the
+     * correct position, enable source maps by default.
+     */
+    "sourceMap": true,
+    "esModuleInterop": true,
+    "types": ["vite/client"],
+    "skipLibCheck": true,
+    /**
+     * Typecheck JS in `.svelte` and `.js` files by default.
+     * Disable this if you'd like to use dynamic types.
+     */
+    "checkJs": true
+  },
+  /**
+   * Use global.d.ts instead of compilerOptions.types
+   * to avoid limiting type declarations.
+   */
+  "include": ["src/**/*.d.ts", "src/**/*.js", "src/**/*.svelte"]
+}

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "frontend",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "devDependencies": {
+    "@sveltejs/vite-plugin-svelte": "^6.2.0",
+    "@tailwindcss/postcss": "^4.1.13",
+    "autoprefixer": "^10.4.21",
+    "postcss": "^8.5.6",
+    "svelte": "^5.39.4",
+    "tailwindcss": "^4.1.13",
+    "vite": "^7.1.7"
+  }
+}

--- a/frontend/postcss.config.js
+++ b/frontend/postcss.config.js
@@ -1,0 +1,6 @@
+export default {
+  plugins: {
+    '@tailwindcss/postcss': {},
+    autoprefixer: {},
+  },
+}

--- a/frontend/public/favicon.svg
+++ b/frontend/public/favicon.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <text x="50%" y="50%" font-size="50" text-anchor="middle" dominant-baseline="central">🎯</text>
+</svg>

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -1,0 +1,9 @@
+<script>
+</script>
+
+<main>
+  <h1>Bingoals Frontend</h1>
+</main>
+
+<style>
+</style>

--- a/frontend/src/app.css
+++ b/frontend/src/app.css
@@ -1,0 +1,9 @@
+@import url('https://fonts.googleapis.com/css2?family=Alegreya+Sans:wght@300;400;700&display=swap');
+
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+body {
+  font-family: theme('fontFamily.sans');
+}

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -1,0 +1,9 @@
+import { mount } from 'svelte'
+import './app.css'
+import App from './App.svelte'
+
+const app = mount(App, {
+  target: document.getElementById('app'),
+})
+
+export default app

--- a/frontend/svelte.config.js
+++ b/frontend/svelte.config.js
@@ -1,0 +1,8 @@
+import { vitePreprocess } from '@sveltejs/vite-plugin-svelte'
+
+/** @type {import("@sveltejs/vite-plugin-svelte").SvelteConfig} */
+export default {
+  // Consult https://svelte.dev/docs#compile-time-svelte-preprocess
+  // for more information about preprocessors
+  preprocess: vitePreprocess(),
+}

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -1,0 +1,15 @@
+/** @type {import('tailwindcss').Config} */
+export default {
+  content: [
+    "./index.html",
+    "./src/**/*.{svelte,js,ts}",
+  ],
+  theme: {
+    extend: {
+      fontFamily: {
+        sans: ['"Alegreya Sans"', 'sans-serif'],
+      },
+    },
+  },
+  plugins: [],
+}

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vite'
+import { svelte } from '@sveltejs/vite-plugin-svelte'
+
+// https://vite.dev/config/
+export default defineConfig({
+  plugins: [svelte()],
+})

--- a/gemini.md
+++ b/gemini.md
@@ -81,3 +81,55 @@ After making code changes, you can automatically fix most linting and formatting
 cd backend
 npm run lint:fix
 ```
+
+---
+
+# Frontend Setup Notes
+
+This section outlines the setup and conventions for the Bingoals frontend.
+
+**Stack:**
+*   **Framework:** Svelte
+*   **Build Tool:** Vite
+*   **Styling:** Tailwind CSS
+*   **Language:** JavaScript (with JSDoc for type checking)
+
+**Key Files and Directories:**
+*   `frontend/index.html`: The main HTML entry point.
+*   `frontend/src/main.js`: The JavaScript entry point for the Svelte application.
+*   `frontend/src/App.svelte`: The root Svelte component.
+*   `frontend/src/app.css`: Global CSS, including Tailwind directives and font imports.
+*   `frontend/tailwind.config.js`: Tailwind CSS configuration, including custom font settings.
+*   `frontend/postcss.config.js`: PostCSS configuration for Tailwind CSS.
+*   `frontend/src/lib/components/`: Directory for reusable Svelte components.
+
+**Font:**
+The primary font used across the application is **Alegreya Sans** from Google Fonts. It is imported via `@import` in `frontend/src/app.css` and configured as the default `sans` font in `frontend/tailwind.config.js`.
+
+**Local Setup Steps:**
+
+1.  **Navigate to the frontend directory:**
+    ```bash
+    cd frontend
+    ```
+2.  **Install dependencies:**
+    ```bash
+    npm install
+    ```
+3.  **Start the development server:**
+    ```bash
+    npm run dev
+    ```
+    This will start the development server, typically accessible at `http://localhost:5173` (or another port if 5173 is in use).
+
+**Design Practices to Minimize Code Bloat:**
+
+To maintain a lean and efficient codebase, we adhere to the following practices:
+
+*   **Component-Based Architecture:** Break down the UI into small, reusable Svelte components. Store these in `frontend/src/lib/components/`.
+*   **Tailwind CSS for Styling:** Leverage Tailwind's utility-first approach to avoid writing custom CSS where possible, promoting consistency and reducing stylesheet size.
+*   **DRY (Don't Repeat Yourself):** Actively identify and refactor duplicated code into reusable functions, stores, or components.
+*   **Minimal Dependencies:** Only introduce new libraries or packages when absolutely necessary and after careful consideration of their impact on bundle size and performance.
+
+*   **Focus on Core Functionality:** Prioritize delivering essential features efficiently, avoiding premature optimization or over-engineering.
+*   **Regular Review and Refactoring:** Periodically review the codebase for opportunities to simplify, optimize, and remove unnecessary code.


### PR DESCRIPTION
This PR initializes the frontend with Svelte, TailwindCSS, and Vite. It sets up the basic project structure and includes initial configuration files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Introduced a Svelte + Vite frontend scaffold with Tailwind CSS.
  - Initial app shell renders “Bingoals Frontend” and applies Alegreya Sans typography.

- Documentation
  - Added frontend README with setup guidance, tooling notes, and HMR behavior.
  - Expanded project notes with frontend setup and design practices.

- Chores
  - Added configuration for build tooling, CSS processing, and TypeScript/JS settings.
  - Included development scripts for dev, build, and preview.
  - Added ignore rules for logs, builds, and editor files.
  - Recommended VS Code extension for Svelte.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->